### PR TITLE
Now we dont activate action when a PR is created into main

### DIFF
--- a/.github/workflows/build-push-simulator-images.yml
+++ b/.github/workflows/build-push-simulator-images.yml
@@ -11,7 +11,8 @@ name: Build and push simulator Docker images
 on:
   # On any PR we will save the docker images as -dev on docker hub
   pull_request:
-  
+    branches-ignore:
+      - main
   # When we merge into main we need to run this on push otherwise we would
   # never have the prod images on docker hub.
   push:


### PR DESCRIPTION
The action of building and uploading the docker images was being triggered when the PR was created (we only want that for dev branches). Now the PR conditions ignores the main branch.