### PR TITLE
Download swash and swan from bucket

### DIFF
--- a/simulators/swan/v41.45/Dockerfile
+++ b/simulators/swan/v41.45/Dockerfile
@@ -54,14 +54,15 @@ ENV LD_LIBRARY_PATH ${OPENMPI_HOME}/lib:$LD_LIBRARY_PATH
 
 # Environment variables and arguments for SWAN
 ENV SWAN_HOME=/swan
-ARG SWAN_VERSION=4145
+ARG SWAN_VERSION=41.45
 ARG SWAN_TMP=/tmp/swan
 ENV SWAN_BIN=swan.exe
 
 # Instal SWAN from source code
 RUN mkdir ${SWAN_TMP}
 WORKDIR ${SWAN_TMP}
-RUN wget https://swanmodel.sourceforge.io/download/zip/swan${SWAN_VERSION}.tar.gz && \
+
+RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swan/v${SWAN_VERSION}/swan${SWAN_VERSION}.tar.gz && \
     tar -xzf swan${SWAN_VERSION}.tar.gz --directory . --strip-components 1 && \
     make config && \
     make mpi && \

--- a/simulators/swash/v10.01/Dockerfile
+++ b/simulators/swash/v10.01/Dockerfile
@@ -64,7 +64,7 @@ ENV SWASH_BIN=swash.exe
 # Download, build, and install SWASH.
 RUN mkdir ${SWASH_TMP}
 WORKDIR ${SWASH_TMP}
-RUN wget https://swash.sourceforge.io/download/zip/swash-${SWASH_VERSION}.tar.gz && \
+RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swash/v10.01/swash-${SWASH_VERSION}.tar.gz && \
     tar -xzf swash-${SWASH_VERSION}.tar.gz --directory . --strip-components 1 && \
     make config && \
     make mpi && \


### PR DESCRIPTION
This pull request updates the download source for the simulators (swash and swan) from the website of the simulators to our bucket. The reason behind this adjustment is that when developers release a new version of the simulator, we lose access to the source code of the previous version. This loss of access prevents us from building simulators based on previous versions, which consequently breaks our dockerfiles. By making this change, we ensure that we have a backup of the source code, enabling our dockerfiles to build any specific version of the simulator whenever necessary.