### PR TITLE
Updated amr, cans and dualsph to use the new base_img

### DIFF
--- a/simulators/amr-wind/v1.4.0/Dockerfile
+++ b/simulators/amr-wind/v1.4.0/Dockerfile
@@ -1,9 +1,6 @@
-FROM ubuntu:22.04 as test_env
+FROM inductiva/kutu:base-image_v0.1.0 as test_env
 
-RUN apt-get update && apt-get install -y \
-    wget \
-    unzip && \
-    wget https://storage.googleapis.com/inductiva-api-demo-files/amr-wind-input-example.zip -P /home/ && \
+RUN wget https://storage.googleapis.com/inductiva-api-demo-files/amr-wind-input-example.zip -P /home/ && \
     unzip /home/amr-wind-input-example.zip -d /home/ && \
     rm /home/amr-wind-input-example.zip 
 
@@ -11,22 +8,10 @@ COPY ./test_sim.sh /home/test_sim.sh
 
 RUN chmod +x /home/test_sim.sh
 
-FROM ubuntu:22.04 as build
+FROM inductiva/kutu:base-image_v0.1.0 as build
 
-RUN apt update -qq && \
-    apt install -y software-properties-common build-essential && \
-    add-apt-repository ppa:git-core/ppa -y && \
-    apt install -y libblas-dev liblapack-dev \
-        libopenmpi-dev=4.1.2-2ubuntu1 \
-        openmpi-bin=4.1.2-2ubuntu1 \
-        gcc gfortran make \
-        python3-pip \
-        libomp-dev \
-        cmake \
-        wget \
-        git && \
     # Fortran compiler
-    export FC=/usr/bin/gfortran && \
+RUN export FC=/usr/bin/gfortran && \
     # Clone Openfast repository
     git clone --recursive --branch v1.4.0 https://github.com/Exawind/amr-wind.git amr-wind && \
     mkdir amr-wind/build && cd amr-wind/build && \
@@ -42,7 +27,7 @@ RUN apt update -qq && \
 FROM ubuntu:22.04
 
 RUN apt update -qq && \
-    apt install -y \
+    apt install --no-install-recommends -y \
         openmpi-bin=4.1.2-2ubuntu1 && \
     apt clean
 

--- a/simulators/cans/v2.3.4/Dockerfile
+++ b/simulators/cans/v2.3.4/Dockerfile
@@ -1,31 +1,45 @@
-FROM ubuntu:22.04 as test_env
+FROM inductiva/kutu:base-image_v0.1.0 as test_env
 
-RUN apt-get update && apt-get install -y \
-    wget \
-    unzip && \
-    wget https://storage.googleapis.com/inductiva-api-demo-files/cans-input-example.zip -P /home/ && \
+RUN wget https://storage.googleapis.com/inductiva-api-demo-files/cans-input-example.zip -P /home/ && \
     unzip /home/cans-input-example.zip -d /home/ && \
-    rm /home/cans-input-example.zip && \
-    ls -l
+    rm /home/cans-input-example.zip
 
 COPY ./test_sim.sh /home/test_sim.sh
 RUN chmod +x /home/test_sim.sh
 
-FROM ubuntu:22.04 as build
+FROM inductiva/kutu:base-image_v0.1.0 as build
 
-RUN apt update -qq && \
-    apt install -y build-essential && \
-    apt install -y  openmpi-bin=4.1.2-2ubuntu1 \
-        libopenmpi-dev=4.1.2-2ubuntu1 \
-        libfftw3-dev \
-        wget \
-        git && \
-    git clone --recursive --branch v2.3.4 https://github.com/CaNS-World/CaNS && \
+RUN git clone --recursive --branch v2.3.4 https://github.com/CaNS-World/CaNS && \
     cd CaNS && \
     make libs && \
     make -j 4 && \
-    cp -a /CaNS/run/* /usr/local/bin/ && \
-    rm -r /CaNS
+    cp -a /CaNS/run/* /usr/local/bin/
 
+FROM ubuntu:22.04
+
+RUN apt update -qq && \
+    apt install --no-install-recommends -y \
+        openmpi-bin=4.1.2-2ubuntu1 && \
+    apt clean
+
+COPY --from=build /lib/x86_64-linux-gnu/libevent_pthreads-2.1.so.7 /lib/x86_64-linux-gnu/libevent_pthreads-2.1.so.7
+COPY --from=build /lib/x86_64-linux-gnu/libevent_core-2.1.so.7 /lib/x86_64-linux-gnu/libevent_core-2.1.so.7
+COPY --from=build /lib/x86_64-linux-gnu/libmpi_mpifh.so.40 /lib/x86_64-linux-gnu/libmpi_mpifh.so.40
+COPY --from=build /lib/x86_64-linux-gnu/libopen-pal.so.40 /lib/x86_64-linux-gnu/libopen-pal.so.40
+COPY --from=build /lib/x86_64-linux-gnu/libopen-rte.so.40 /lib/x86_64-linux-gnu/libopen-rte.so.40
+COPY --from=build /lib/x86_64-linux-gnu/libgfortran.so.5 /lib/x86_64-linux-gnu/libgfortran.so.5
+COPY --from=build /lib/x86_64-linux-gnu/libquadmath.so.0 /lib/x86_64-linux-gnu/libquadmath.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libhwloc.so.15 /lib/x86_64-linux-gnu/libhwloc.so.15
+COPY --from=build /lib/x86_64-linux-gnu/libfftw3.so.3 /lib/x86_64-linux-gnu/libfftw3.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libmpi.so.40 /lib/x86_64-linux-gnu/libmpi.so.40
+COPY --from=build /lib/x86_64-linux-gnu/libmvec.so.1 /lib/x86_64-linux-gnu/libmvec.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libudev.so.1 /lib/x86_64-linux-gnu/libudev.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 
 COPY --from=test_env /home /home
+
+COPY --from=build /CaNS/run/ /usr/local/bin/

--- a/simulators/dualsphysics/v5.2.1/Dockerfile
+++ b/simulators/dualsphysics/v5.2.1/Dockerfile
@@ -1,8 +1,6 @@
-FROM ubuntu:22.04 as test_env
+FROM inductiva/kutu:base-image_v0.1.0 as test_env
 
-RUN apt-get update -y; \
-    apt-get install curl unzip -y; \
-    curl https://storage.googleapis.com/inductiva-api-demo-files/dualsphysics-input-example.zip\ 
+RUN curl https://storage.googleapis.com/inductiva-api-demo-files/dualsphysics-input-example.zip\ 
         --output /home/dualsphysics-input-example.zip && \
     unzip /home/dualsphysics-input-example.zip -d /home/ && \
     rm /home/dualsphysics-input-example.zip && \
@@ -14,22 +12,10 @@ COPY ./test_sim.sh /home/test_sim.sh
 RUN chmod +x /home/test_sim.sh
 
 # Start from an image provided by NVIDIA with CUDA 11.7.
-FROM ubuntu:22.04 as build
+FROM inductiva/kutu:base-image_v0.1.0 as build
 
 # Set frontend to be noninteractive, to avoid prompts during installation.
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Install git and cmake.
-RUN apt-get update -y \
-    && apt-get install -y git cmake wget unzip
-
-# Install Python 3.11.
-RUN apt-get update -y; \
-    apt-get install curl software-properties-common g++ -y; \
-    add-apt-repository ppa:deadsnakes/ppa; \
-    apt-get install -y python3.11 python3.11-distutils; \
-    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11; \
-    rm -f /usr/bin/python && ln -s /usr/bin/python3.11 /usr/bin/python
 
 # Clone the DualSPHysics repository.
 WORKDIR /
@@ -52,7 +38,6 @@ RUN wget -O DualSPHysics_v5.2.zip  https://storage.googleapis.com/inductiva-host
 # Build DualSPHysics.
 WORKDIR /DualSPHysics_v5.2/src/source/build
 RUN CC=gcc CXX=g++ cmake .. && make DualSPHysics5.2CPU_linux64
-
 
 FROM ubuntu:22.04 
 


### PR DESCRIPTION
This PR changes amr, cans and dualsph to use the new inductiva base-image to build the simulators. 