### PR TITLE
Add mpi4py to openseesPy

### DIFF
--- a/simulators/openseespy/v3.7.1/Dockerfile
+++ b/simulators/openseespy/v3.7.1/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install openseespy==3.7.1.2 && \
     pip install sees==0.0.25 && \
+    pip install mpi4py && \
     cp /usr/bin/python3 /usr/bin/python
 
 COPY --from=test_env /home /home


### PR DESCRIPTION
Opensees uses its own way to detect the number of processors with `ops.getNP()` but that does not work as expected sometimes. So, we installed mpi4py for users to be able to get the number of processors.

source: https://github.com/OpenSees/OpenSees/issues/1587