### PR TITLE
Make all mpirun commands use machinefile

### DIFF
--- a/simulators/swan/v41.31/Dockerfile
+++ b/simulators/swan/v41.31/Dockerfile
@@ -72,7 +72,8 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swan/v${SWA
     mv swan.exe swanrun ${SWAN_HOME} && \
     chmod +rx ${SWAN_HOME}/swanrun && \
     rm -rf ${SWAN_TMP} && \
-    sed -i '2i set -e' ${SWAN_HOME}/swanrun
+    sed -i '2i set -e' ${SWAN_HOME}/swanrun && \
+    sed 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
 ENV PATH ${SWAN_HOME}:$PATH
 
 COPY --from=test_env /home /home

--- a/simulators/swan/v41.31/Dockerfile
+++ b/simulators/swan/v41.31/Dockerfile
@@ -73,7 +73,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swan/v${SWA
     chmod +rx ${SWAN_HOME}/swanrun && \
     rm -rf ${SWAN_TMP} && \
     sed -i '2i set -e' ${SWAN_HOME}/swanrun && \
-    sed 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
+    sed -i 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
 ENV PATH ${SWAN_HOME}:$PATH
 
 COPY --from=test_env /home /home

--- a/simulators/swan/v41.45/Dockerfile
+++ b/simulators/swan/v41.45/Dockerfile
@@ -71,7 +71,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swan/v${SWA
     chmod +rx ${SWAN_HOME}/swanrun && \
     rm -rf ${SWAN_TMP} && \
     sed -i '2i set -e' ${SWAN_HOME}/swanrun && \
-    sed 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
+    sed -i 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
     
 ENV PATH ${SWAN_HOME}:$PATH
 

--- a/simulators/swan/v41.45/Dockerfile
+++ b/simulators/swan/v41.45/Dockerfile
@@ -70,7 +70,8 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swan/v${SWA
     mv swan.exe swanrun ${SWAN_HOME} && \
     chmod +rx ${SWAN_HOME}/swanrun && \
     rm -rf ${SWAN_TMP} && \
-    sed -i '2i set -e' ${SWAN_HOME}/swanrun
+    sed -i '2i set -e' ${SWAN_HOME}/swanrun && \
+    sed 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
     
 ENV PATH ${SWAN_HOME}:$PATH
 

--- a/simulators/swan/v41.51/Dockerfile
+++ b/simulators/swan/v41.51/Dockerfile
@@ -46,7 +46,8 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swan/v${SWA
     cp bin/swan.exe bin/hcat.exe ../bin/swanrun ${SWAN_HOME} && \
     chmod +rx ${SWAN_HOME}/swanrun && \
     rm -rf ${SWAN_TMP} && \
-    sed -i '2i set -e' ${SWAN_HOME}/swanrun
+    sed -i '2i set -e' ${SWAN_HOME}/swanrun && \
+    sed 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
 
 ENV PATH ${SWAN_HOME}:$PATH
 

--- a/simulators/swan/v41.51/Dockerfile
+++ b/simulators/swan/v41.51/Dockerfile
@@ -47,7 +47,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swan/v${SWA
     chmod +rx ${SWAN_HOME}/swanrun && \
     rm -rf ${SWAN_TMP} && \
     sed -i '2i set -e' ${SWAN_HOME}/swanrun && \
-    sed 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
+    sed -i 's/mpirun -np \$npmpi swan.exe/mpirun -np \$npmpi -machinefile machinefile swan.exe/' ${SWAN_HOME}/swanrun
 
 ENV PATH ${SWAN_HOME}:$PATH
 

--- a/simulators/swash/v10.01A/Dockerfile
+++ b/simulators/swash/v10.01A/Dockerfile
@@ -72,7 +72,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swash/v${SW
     mv swash.exe swashrun ${SWASH_HOME} && \
     chmod +rx ${SWASH_HOME}/swashrun && \
     sed -i '2i set -e' ${SWASH_HOME}/swashrun && \
-    sed 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
+    sed -i 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
     rm -rf ${SWASH_TMP}
 ENV PATH ${SWASH_HOME}:$PATH
 

--- a/simulators/swash/v10.01A/Dockerfile
+++ b/simulators/swash/v10.01A/Dockerfile
@@ -72,6 +72,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swash/v${SW
     mv swash.exe swashrun ${SWASH_HOME} && \
     chmod +rx ${SWASH_HOME}/swashrun && \
     sed -i '2i set -e' ${SWASH_HOME}/swashrun && \
+    sed 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
     rm -rf ${SWASH_TMP}
 ENV PATH ${SWASH_HOME}:$PATH
 

--- a/simulators/swash/v10.05/Dockerfile
+++ b/simulators/swash/v10.05/Dockerfile
@@ -72,7 +72,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swash/v${SW
     mv swash.exe swashrun ${SWASH_HOME} && \
     chmod +rx ${SWASH_HOME}/swashrun && \
     sed -i '2i set -e' ${SWASH_HOME}/swashrun && \
-    sed 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
+    sed -i 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
     rm -rf ${SWASH_TMP}
 ENV PATH ${SWASH_HOME}:$PATH
 

--- a/simulators/swash/v10.05/Dockerfile
+++ b/simulators/swash/v10.05/Dockerfile
@@ -72,6 +72,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swash/v${SW
     mv swash.exe swashrun ${SWASH_HOME} && \
     chmod +rx ${SWASH_HOME}/swashrun && \
     sed -i '2i set -e' ${SWASH_HOME}/swashrun && \
+    sed 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
     rm -rf ${SWASH_TMP}
 ENV PATH ${SWASH_HOME}:$PATH
 

--- a/simulators/swash/v11.01/Dockerfile
+++ b/simulators/swash/v11.01/Dockerfile
@@ -72,7 +72,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swash/v${SW
     mv swash.exe swashrun ${SWASH_HOME} && \
     chmod +rx ${SWASH_HOME}/swashrun && \
     sed -i '2i set -e' ${SWASH_HOME}/swashrun && \
-    sed 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
+    sed -i 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
     rm -rf ${SWASH_TMP}
 ENV PATH ${SWASH_HOME}:$PATH
 

--- a/simulators/swash/v11.01/Dockerfile
+++ b/simulators/swash/v11.01/Dockerfile
@@ -72,6 +72,7 @@ RUN wget https://storage.googleapis.com/inductiva-simulators-sources/swash/v${SW
     mv swash.exe swashrun ${SWASH_HOME} && \
     chmod +rx ${SWASH_HOME}/swashrun && \
     sed -i '2i set -e' ${SWASH_HOME}/swashrun && \
+    sed 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' ${SWASH_HOME}/swashrun && \
     rm -rf ${SWASH_TMP}
 ENV PATH ${SWASH_HOME}:$PATH
 

--- a/simulators/swash/v9.01A/Dockerfile
+++ b/simulators/swash/v9.01A/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone https://gitlab.tudelft.nl/citg/wavemodels/swash.git && \
     cd / && \
     rm -rf ${SWASH_TMP} && \
     sed -i '2i set -e' /swash/bin/swashrun && \
-    sed 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' /swash/bin/swashrun
+    sed -i 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' /swash/bin/swashrun
 
 
 

--- a/simulators/swash/v9.01A/Dockerfile
+++ b/simulators/swash/v9.01A/Dockerfile
@@ -33,7 +33,9 @@ RUN git clone https://gitlab.tudelft.nl/citg/wavemodels/swash.git && \
     cmake --install . && \
     cd / && \
     rm -rf ${SWASH_TMP} && \
-    sed -i '2i set -e' /swash/bin/swashrun
+    sed -i '2i set -e' /swash/bin/swashrun && \
+    sed 's/mpirun -np \$npmpi swash.exe/mpirun -np \$npmpi -machinefile machinefile swash.exe/' /swash/bin/swashrun
+
 
 
 FROM ubuntu:22.04


### PR DESCRIPTION
Swan and swash where only using the machinefile for machines with 8 or more cores.

This was causing an error when running on machines with 4 vcpus (as an example). It would try to run `mpirun -np 4 swan.exe` but this would fail because we had no hyperthreading enabled. 

By using the machinefile this should be fixed.