### PR TITLE
Limite openmp threads to 1

### DIFF
--- a/simulators/nwchem/v7.2.2/Dockerfile
+++ b/simulators/nwchem/v7.2.2/Dockerfile
@@ -47,6 +47,8 @@ RUN apt update -qq && \
         openmpi-bin=4.1.2-2ubuntu1 && \
     apt clean
 
+ENV OMP_NUM_THREADS=1
+
 COPY --from=build /lib/x86_64-linux-gnu/libscalapack-openmpi.so.2.1 /lib/x86_64-linux-gnu/libscalapack-openmpi.so.2.1
 COPY --from=build /lib/x86_64-linux-gnu/libevent_pthreads-2.1.so.7 /lib/x86_64-linux-gnu/libevent_pthreads-2.1.so.7
 COPY --from=build /lib/x86_64-linux-gnu/libevent_core-2.1.so.7 /lib/x86_64-linux-gnu/libevent_core-2.1.so.7

--- a/simulators/nwchem/v7.2.3/Dockerfile
+++ b/simulators/nwchem/v7.2.3/Dockerfile
@@ -47,6 +47,8 @@ RUN apt update -qq && \
         openmpi-bin=4.1.2-2ubuntu1 && \
     apt clean
 
+ENV OMP_NUM_THREADS=1
+
 COPY --from=build /lib/x86_64-linux-gnu/libscalapack-openmpi.so.2.1 /lib/x86_64-linux-gnu/libscalapack-openmpi.so.2.1
 COPY --from=build /lib/x86_64-linux-gnu/libevent_pthreads-2.1.so.7 /lib/x86_64-linux-gnu/libevent_pthreads-2.1.so.7
 COPY --from=build /lib/x86_64-linux-gnu/libevent_core-2.1.so.7 /lib/x86_64-linux-gnu/libevent_core-2.1.so.7


### PR DESCRIPTION
I'm doing this to avoid having an explosion of threads with mpi and openmp.