### PR TITLE
Add intel mkl libraries to fds images

### DIFF
--- a/simulators/fds/v6.10.1/Dockerfile
+++ b/simulators/fds/v6.10.1/Dockerfile
@@ -98,6 +98,7 @@ RUN wget https://github.com/firemodels/fds/releases/download/FDS-6.10.1/FDS-6.10
     git;
 
 ENV PATH=/opt/smokeview/smvbin:$PATH
+ENV DISPLAY=:1
 
 COPY --from=build_env /opt/fds /opt/fds
 RUN ln -s /opt/fds/Build/ompi_gnu_linux/fds_ompi_gnu_linux /usr/bin/fds

--- a/simulators/fds/v6.8/Dockerfile
+++ b/simulators/fds/v6.8/Dockerfile
@@ -98,6 +98,7 @@ RUN wget https://github.com/firemodels/fds/releases/download/FDS-6.8.0/FDS-6.8.0
     git;
 
 ENV PATH=/opt/smokeview/smvbin:$PATH
+ENV DISPLAY=:1
 
 COPY --from=build_env /opt/fds /opt/fds
 RUN ln -s /opt/fds/Build/ompi_gnu_linux/fds_ompi_gnu_linux /usr/bin/fds

--- a/simulators/fds/v6.9.1/Dockerfile
+++ b/simulators/fds/v6.9.1/Dockerfile
@@ -98,6 +98,7 @@ RUN wget https://github.com/firemodels/fds/releases/download/FDS-6.9.1/FDS-6.9.1
     git;
 
 ENV PATH=/opt/smokeview/smvbin:$PATH
+ENV DISPLAY=:1
 
 COPY --from=build_env /opt/fds /opt/fds
 RUN ln -s /opt/fds/Build/ompi_gnu_linux/fds_ompi_gnu_linux /usr/bin/fds


### PR DESCRIPTION
Some solvers that FDS uses require FDS to be compiled with the Intel MKL libraries.